### PR TITLE
Add leverage instrument comparison: futures vs box spreads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ retirement_math.py   (imports all — thin CLI layer)
   - `generic` — borrowing cost only, no tax drag (default, backward-compatible)
   - `futures` — Section 1256 mark-to-market: annual tax on gains (~26.8% blended 60/40 rate), low financing spread (20bps), quarterly roll cost (10bps/yr). Loss carryforward not modeled (conservative).
   - `box_spread` — box spread + ETF: capital gains deferred, annual dividend tax drag (`leverage × div_yield × div_tax_rate`), higher financing spread (40bps), crisis spread widening (+100bps when stock excess return < -10%)
-- **Kelly Optimal Leverage**: `L* = (ERP - spread) / σ²` — spread is instrument-aware (futures uses financing_spread + roll_cost, box_spread uses financing_spread)
+- **Kelly Optimal Leverage**: Tax-adjusted Kelly formula. Generic: `L* = (ERP - spread) / σ²`. Futures: `L* = (ERP - spread) × (1 - tax_rate) / σ²` (mark-to-market tax reduces expected excess). Box spread: `L* = (ERP - spread - div_yield × div_tax_rate) / σ²` (dividend tax as leverage-proportional cost). **Note**: Kelly still assumes log utility, normal returns, no margin calls — actual optimal from sweeps is typically lower
 - **Margin Calls**: `LeveragedStockPortfolio` triggers forced liquidation when equity drops below `maintenance_margin` (default 25%), reducing leverage for a 2-year cooldown
 - **Stochastic Lifespan**: Gompertz mortality `h(age) = a·exp(b·age)` — spending rules still plan for `expected_lifespan`, but simulation terminates at sampled death age (longevity risk)
 - **Stochastic Income**: Market-correlated job loss `P(loss) = base · exp(sensitivity · max(0, -excess_return))` — income shocks during working years

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Modular flat-file layout with three composable layers. All files live in the pro
 |------|---------|-------|
 | `retirement_math.py` | CLI entry point: `parse_args()` + `main()` | ~200 |
 | `config.py` | `SimulationConfig`, `SimulationResult`, `post_tax`, `format_money` | ~250 |
-| `models.py` | Vitality, SS benefit, Vasicek yields, Kelly, Gompertz mortality, Bayesian sampling | ~110 |
+| `models.py` | Vitality, SS benefit, Vasicek yields, Gompertz mortality, Bayesian sampling | ~110 |
 | `spending.py` | `YearContext`, `SpendingRule` ABC, `FixedSpending`, `AmortizedSpending`, `VitalityAmortizedSpending`, `MarginalUtilitySpending` | ~230 |
 | `utility.py` | `UtilityScorer` ABC, `CRRAUtility` | ~80 |
 | `simulator.py` | `run_simulation`, `_build_income_schedule`, `_generate_year_shocks` | ~200 |
@@ -111,7 +111,6 @@ retirement_math.py   (imports all — thin CLI layer)
   - `generic` — borrowing cost only, no tax drag (default, backward-compatible)
   - `futures` — Section 1256 mark-to-market: annual tax on gains (~26.8% blended 60/40 rate), low financing spread (20bps), quarterly roll cost (10bps/yr). Loss carryforward not modeled (conservative).
   - `box_spread` — box spread + ETF: capital gains deferred, annual dividend tax drag (`leverage × div_yield × div_tax_rate`), higher financing spread (40bps), crisis spread widening (+100bps when stock excess return < -10%)
-- **Kelly Optimal Leverage**: Tax-adjusted Kelly formula. Generic: `L* = (ERP - spread) / σ²`. Futures: `L* = (ERP - spread) × (1 - tax_rate) / σ²` (mark-to-market tax reduces expected excess). Box spread: `L* = (ERP - spread - div_yield × div_tax_rate) / σ²` (dividend tax as leverage-proportional cost). **Note**: Kelly still assumes log utility, normal returns, no margin calls — actual optimal from sweeps is typically lower
 - **Margin Calls**: `LeveragedStockPortfolio` triggers forced liquidation when equity drops below `maintenance_margin` (default 25%), reducing leverage for a 2-year cooldown
 - **Stochastic Lifespan**: Gompertz mortality `h(age) = a·exp(b·age)` — spending rules still plan for `expected_lifespan`, but simulation terminates at sampled death age (longevity risk)
 - **Stochastic Income**: Market-correlated job loss `P(loss) = base · exp(sensitivity · max(0, -excess_return))` — income shocks during working years

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ Available parameters: `retirement-age`, `leverage`, `erp`, `stock-vol`, `fire-mu
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--leverage` | 2.0 | Leverage ratio for leveraged portfolio |
-| `--optimal-leverage` | — | Use Kelly-optimal leverage instead |
 | `--maintenance-margin` | 0.25 | Margin call equity threshold |
 | `--no-margin-calls` | — | Disable margin call mechanics |
 
@@ -261,8 +260,6 @@ python retirement_math.py --amortized --seed 42
 ### "What leverage should I use?"
 ```bash
 python retirement_math.py --leverage-sweep 500
-# Or use Kelly-optimal:
-python retirement_math.py --optimal-leverage
 ```
 
 ### "What's the joint optimal retirement age and leverage?"
@@ -294,7 +291,7 @@ All flat files in the project root (no package — `python retirement_math.py` w
 |------|---------|
 | `retirement_math.py` | CLI entry point (`parse_args` + `main`) |
 | `config.py` | `SimulationConfig`, `SimulationResult`, tax/formatting helpers |
-| `models.py` | Vitality, Social Security, Vasicek yields, Kelly, Gompertz, Bayesian sampling |
+| `models.py` | Vitality, Social Security, Vasicek yields, Gompertz, Bayesian sampling |
 | `spending.py` | `SpendingRule` ABC, `FixedSpending`, `AmortizedSpending`, `VitalityAmortizedSpending`, `MarginalUtilitySpending` |
 | `utility.py` | `UtilityScorer` ABC, `CRRAUtility` |
 | `simulator.py` | `run_simulation` — the core financial model |

--- a/models.py
+++ b/models.py
@@ -98,39 +98,6 @@ def compute_ss_benefit(config: SimulationConfig,
     return max(0.0, net_ss)
 
 
-def compute_optimal_leverage(config: SimulationConfig) -> float:
-    """Compute tax-adjusted Kelly-optimal leverage.
-
-    Base Kelly: L* = excess_return / sigma^2
-
-    Tax adjustments by instrument:
-    - Generic: L* = (ERP - margin_spread) / σ²
-    - Futures: mark-to-market tax reduces expected excess by (1 - tax_rate):
-              L* = (ERP - spread) * (1 - futures_tax_rate) / σ²
-    - Box spread: dividend tax acts as additional leverage-proportional cost:
-              L* = (ERP - spread - div_yield * div_tax_rate) / σ²
-
-    Note: Even with tax adjustment, Kelly assumes log utility, normal returns,
-    no margin calls, and constant vol. The simulation uses CRRA, fat tails,
-    margin calls, and stochastic vol — actual optimal is typically lower.
-    Use leverage sweeps for authoritative recommendations.
-    """
-    if config.leverage_instrument == 'futures':
-        spread = config.futures_financing_spread + config.futures_roll_cost
-        # Mark-to-market tax reduces expected excess return
-        excess = (config.equity_risk_premium - spread) * (1 - config.futures_tax_rate)
-    elif config.leverage_instrument == 'box_spread':
-        # Dividend tax acts as leverage-proportional cost
-        spread = (config.box_spread_financing_spread
-                  + config.box_div_yield * config.box_div_tax_rate)
-        excess = config.equity_risk_premium - spread
-    else:
-        spread = config.margin_spread
-        excess = config.equity_risk_premium - spread
-    if excess <= 0:
-        return 1.0
-    return excess / config.stock_vol ** 2
-
 
 def evolve_bond_yield(
     current_yield: float,

--- a/models.py
+++ b/models.py
@@ -99,18 +99,34 @@ def compute_ss_benefit(config: SimulationConfig,
 
 
 def compute_optimal_leverage(config: SimulationConfig) -> float:
-    """Compute Kelly-optimal leverage: L* = (ERP - spread) / sigma^2.
+    """Compute tax-adjusted Kelly-optimal leverage.
 
-    Uses instrument-specific spread: futures includes roll cost,
-    box_spread uses its financing spread, generic uses margin_spread.
+    Base Kelly: L* = excess_return / sigma^2
+
+    Tax adjustments by instrument:
+    - Generic: L* = (ERP - margin_spread) / σ²
+    - Futures: mark-to-market tax reduces expected excess by (1 - tax_rate):
+              L* = (ERP - spread) * (1 - futures_tax_rate) / σ²
+    - Box spread: dividend tax acts as additional leverage-proportional cost:
+              L* = (ERP - spread - div_yield * div_tax_rate) / σ²
+
+    Note: Even with tax adjustment, Kelly assumes log utility, normal returns,
+    no margin calls, and constant vol. The simulation uses CRRA, fat tails,
+    margin calls, and stochastic vol — actual optimal is typically lower.
+    Use leverage sweeps for authoritative recommendations.
     """
     if config.leverage_instrument == 'futures':
         spread = config.futures_financing_spread + config.futures_roll_cost
+        # Mark-to-market tax reduces expected excess return
+        excess = (config.equity_risk_premium - spread) * (1 - config.futures_tax_rate)
     elif config.leverage_instrument == 'box_spread':
-        spread = config.box_spread_financing_spread
+        # Dividend tax acts as leverage-proportional cost
+        spread = (config.box_spread_financing_spread
+                  + config.box_div_yield * config.box_div_tax_rate)
+        excess = config.equity_risk_premium - spread
     else:
         spread = config.margin_spread
-    excess = config.equity_risk_premium - spread
+        excess = config.equity_risk_premium - spread
     if excess <= 0:
         return 1.0
     return excess / config.stock_vol ** 2

--- a/models.py
+++ b/models.py
@@ -99,8 +99,18 @@ def compute_ss_benefit(config: SimulationConfig,
 
 
 def compute_optimal_leverage(config: SimulationConfig) -> float:
-    """Compute Kelly-optimal leverage: L* = (ERP - spread) / sigma^2."""
-    excess = config.equity_risk_premium - config.margin_spread
+    """Compute Kelly-optimal leverage: L* = (ERP - spread) / sigma^2.
+
+    Uses instrument-specific spread: futures includes roll cost,
+    box_spread uses its financing spread, generic uses margin_spread.
+    """
+    if config.leverage_instrument == 'futures':
+        spread = config.futures_financing_spread + config.futures_roll_cost
+    elif config.leverage_instrument == 'box_spread':
+        spread = config.box_spread_financing_spread
+    else:
+        spread = config.margin_spread
+    excess = config.equity_risk_premium - spread
     if excess <= 0:
         return 1.0
     return excess / config.stock_vol ** 2

--- a/plotting.py
+++ b/plotting.py
@@ -7,7 +7,6 @@ from typing import Dict
 import numpy as np
 
 from config import SimulationConfig, SimulationResult, format_money
-from models import compute_optimal_leverage
 from sweeps import LOG_SCALE_PARAMS
 
 
@@ -81,7 +80,6 @@ def plot_leverage_sweep(sweep: Dict[str, list], config: SimulationConfig) -> Non
     """Plot leverage sweep: NW percentiles, ruin probability, and CE."""
     plt = _get_plt()
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(18, 6))
-    kelly = compute_optimal_leverage(config)
     levs = sweep['leverage']
 
     ax1.fill_between(levs, sweep['p10_nw'], sweep['p90_nw'],
@@ -89,8 +87,6 @@ def plot_leverage_sweep(sweep: Dict[str, list], config: SimulationConfig) -> Non
     ax1.fill_between(levs, sweep['p25_nw'], sweep['p75_nw'],
                      alpha=0.3, label='25th-75th %ile')
     ax1.plot(levs, sweep['median_nw'], 'o-', linewidth=2, label='Median')
-    ax1.axvline(x=kelly, color='green', linestyle='--', alpha=0.7,
-                label=f'Kelly optimal ({kelly:.2f}x)')
     ax1.axhline(y=0, color='r', linestyle='--', alpha=0.3)
     ax1.set_xlabel('Leverage Ratio')
     ax1.set_ylabel('Final Net Worth ($M)')
@@ -102,8 +98,6 @@ def plot_leverage_sweep(sweep: Dict[str, list], config: SimulationConfig) -> Non
              linewidth=2, color='red')
     ax2.axhline(y=5, color='orange', linestyle='--', alpha=0.7,
                 label='5% risk threshold')
-    ax2.axvline(x=kelly, color='green', linestyle='--', alpha=0.7,
-                label=f'Kelly optimal ({kelly:.2f}x)')
     ax2.set_xlabel('Leverage Ratio')
     ax2.set_ylabel('Ruin Probability (%)')
     ax2.set_title('Ruin Risk vs Leverage')
@@ -112,8 +106,6 @@ def plot_leverage_sweep(sweep: Dict[str, list], config: SimulationConfig) -> Non
 
     u_vals = sweep['mean_utility']
     ax3.plot(levs, u_vals, 'o-', linewidth=2, color='purple')
-    ax3.axvline(x=kelly, color='green', linestyle='--', alpha=0.7,
-                label=f'Kelly optimal ({kelly:.2f}x)')
     best_idx = int(np.argmax(u_vals))
     ax3.axvline(x=levs[best_idx], color='purple', linestyle=':',
                 alpha=0.7, label=f'Max E[U] ({levs[best_idx]:.2f}x)')

--- a/retirement_math.py
+++ b/retirement_math.py
@@ -232,7 +232,8 @@ def main() -> None:
 
     if args.optimal_leverage:
         config.leverage_ratio = compute_optimal_leverage(config)
-        print(f"Using Kelly-optimal leverage: {config.leverage_ratio:.2f}x")
+        kelly_label = "Kelly (tax-adj)" if config.leverage_instrument != 'generic' else "Kelly-optimal"
+        print(f"Using {kelly_label} leverage: {config.leverage_ratio:.2f}x")
 
     # Build spending rule (Decision Model)
     if args.amortized or args.retirement_sweep > 0 or args.sweep_2d:
@@ -294,7 +295,8 @@ def main() -> None:
     elif args.leverage_sweep > 0:
         print(f"Running leverage sweep ({args.leverage_sweep} sims per level)...")
         kelly = compute_optimal_leverage(config)
-        print(f"Kelly optimal: {kelly:.2f}x  |  Half-Kelly: {kelly/2:.2f}x")
+        kelly_label = "Kelly (tax-adj)" if config.leverage_instrument != 'generic' else "Kelly optimal"
+        print(f"{kelly_label}: {kelly:.2f}x  |  Half-Kelly: {kelly/2:.2f}x")
         print(f"Spending: {type(spending_rule).__name__}")
         print()
         sweep = run_leverage_sweep(config, spending_rule, utility_scorer,

--- a/retirement_math.py
+++ b/retirement_math.py
@@ -10,6 +10,7 @@ from config import SimulationConfig, format_money, load_env
 from models import compute_optimal_leverage
 from plotting import (
     plot_2d_sweep,
+    plot_instrument_comparison,
     plot_leverage_sweep,
     plot_monte_carlo,
     plot_results,
@@ -27,6 +28,7 @@ from sweeps import (
     PORTFOLIO_NAME_MAP,
     _make_param_range,
     run_2d_sweep,
+    run_instrument_comparison,
     run_leverage_sweep,
     run_monte_carlo,
     run_retirement_sweep,
@@ -65,6 +67,29 @@ def parse_args() -> argparse.Namespace:
                         help='Leverage ratio for leveraged portfolio (default: 2.0)')
     parser.add_argument('--optimal-leverage', action='store_true',
                         help='Use Kelly-optimal leverage instead of --leverage')
+    parser.add_argument('--leverage-instrument', default='generic',
+                        choices=['generic', 'futures', 'box_spread'],
+                        help='Leverage implementation: generic (current), futures '
+                             '(Section 1256 mark-to-market), box_spread (tax-deferred) '
+                             '(default: generic)')
+    parser.add_argument('--instrument-sweep', type=int, default=0, metavar='N',
+                        help='Compare all leverage instruments with N sims each')
+    # Futures-specific
+    parser.add_argument('--futures-tax-rate', type=float, default=0.268,
+                        help='Blended 1256 mark-to-market tax rate (default: 0.268)')
+    parser.add_argument('--futures-spread', type=float, default=0.002,
+                        help='Futures implied financing spread (default: 0.002)')
+    parser.add_argument('--futures-roll-cost', type=float, default=0.001,
+                        help='Annual futures rolling cost (default: 0.001)')
+    # Box spread-specific
+    parser.add_argument('--box-spread', type=float, default=0.004,
+                        help='Box spread financing premium (default: 0.004)')
+    parser.add_argument('--box-div-yield', type=float, default=0.013,
+                        help='Equity dividend yield for box spread tax (default: 0.013)')
+    parser.add_argument('--box-div-tax-rate', type=float, default=0.238,
+                        help='Qualified dividend tax rate (default: 0.238)')
+    parser.add_argument('--box-crisis-widening', type=float, default=0.01,
+                        help='Box spread cost widening during crises (default: 0.01)')
     # Simulation mode
     parser.add_argument('--monte-carlo', type=int, default=0, metavar='N',
                         help='Run N Monte Carlo simulations (default: 0 = single run)')
@@ -172,6 +197,14 @@ def main() -> None:
         initial_bond_yield=args.bond_yield,
         long_run_bond_yield=args.bond_yield,
         margin_spread=args.margin_spread,
+        leverage_instrument=args.leverage_instrument,
+        futures_tax_rate=args.futures_tax_rate,
+        futures_financing_spread=args.futures_spread,
+        futures_roll_cost=args.futures_roll_cost,
+        box_spread_financing_spread=args.box_spread,
+        box_div_yield=args.box_div_yield,
+        box_div_tax_rate=args.box_div_tax_rate,
+        box_crisis_spread_widening=args.box_crisis_widening,
         leverage_ratio=args.leverage,
         utility_power=args.utility_power,
         discount_rate=args.discount_rate,
@@ -215,7 +248,16 @@ def main() -> None:
 
     sim_years = config.expected_lifespan - config.start_age + 1
 
-    if args.sweep_2d:
+    if args.instrument_sweep > 0:
+        print(f"Running instrument comparison ({args.instrument_sweep} sims per point)...")
+        kelly = compute_optimal_leverage(config)
+        print(f"Kelly optimal (generic): {kelly:.2f}x  |  Half-Kelly: {kelly/2:.2f}x")
+        print(f"Spending: {type(spending_rule).__name__}")
+        inst_results = run_instrument_comparison(
+            config, spending_rule, utility_scorer,
+            n_simulations=args.instrument_sweep)
+        plot_instrument_comparison(inst_results, config)
+    elif args.sweep_2d:
         p1_cli, p2_cli, n_str = args.sweep_2d
         n_sims = int(n_str)
         p1 = PARAM_MAP[p1_cli]

--- a/simulator.py
+++ b/simulator.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from config import SimulationConfig, SimulationResult, format_money, post_tax
 from models import (
-    compute_optimal_leverage,
     compute_ss_benefit,
     evolve_bond_yield,
     sample_death_age,
@@ -114,12 +113,10 @@ def run_simulation(
     ss_benefit = compute_ss_benefit(config)
 
     if not quiet:
-        kelly = compute_optimal_leverage(config)
         print(f"Simulation seed: {seed}")
         print(f"E[stock return] = bond_yield + ERP = ~{config.initial_bond_yield + config.equity_risk_premium:.1%}")
         print(f"Margin fee = bond_yield + spread = ~{config.initial_bond_yield + config.margin_spread:.1%}")
-        kelly_label = "Kelly (tax-adj)" if config.leverage_instrument != 'generic' else "Kelly optimal"
-        print(f"{kelly_label}: {kelly:.2f}x  |  Half-Kelly: {kelly/2:.2f}x  |  Using: {config.leverage_ratio:.2f}x")
+        print(f"Using leverage: {config.leverage_ratio:.2f}x")
         tail_desc = f"Student-t(df={config.stock_tail_df:.0f})" if config.stock_tail_df <= 100 else "Normal"
         print(f"Return dist: {tail_desc}  |  Vol clustering: rho={config.vol_persistence}, eta={config.vol_of_vol}")
         print(f"Stock-bond corr: {config.stock_bond_corr:+.2f}")

--- a/simulator.py
+++ b/simulator.py
@@ -118,7 +118,8 @@ def run_simulation(
         print(f"Simulation seed: {seed}")
         print(f"E[stock return] = bond_yield + ERP = ~{config.initial_bond_yield + config.equity_risk_premium:.1%}")
         print(f"Margin fee = bond_yield + spread = ~{config.initial_bond_yield + config.margin_spread:.1%}")
-        print(f"Kelly optimal leverage: {kelly:.2f}x  |  Half-Kelly: {kelly/2:.2f}x  |  Using: {config.leverage_ratio:.2f}x")
+        kelly_label = "Kelly (tax-adj)" if config.leverage_instrument != 'generic' else "Kelly optimal"
+        print(f"{kelly_label}: {kelly:.2f}x  |  Half-Kelly: {kelly/2:.2f}x  |  Using: {config.leverage_ratio:.2f}x")
         tail_desc = f"Student-t(df={config.stock_tail_df:.0f})" if config.stock_tail_df <= 100 else "Normal"
         print(f"Return dist: {tail_desc}  |  Vol clustering: rho={config.vol_persistence}, eta={config.vol_of_vol}")
         print(f"Stock-bond corr: {config.stock_bond_corr:+.2f}")


### PR DESCRIPTION
## Summary
This PR adds support for comparing different leverage instruments (generic margin, Section 1256 futures, and box spread + ETF strategies) with instrument-specific tax and cost treatments. It removes the Kelly-optimal leverage calculation and replaces it with a new `--instrument-sweep` mode that compares all three instruments across leverage levels.

## Key Changes

### New Leverage Instruments
- **`LeveragedStockPortfolio`** now accepts an `instrument` parameter with three modes:
  - `generic`: Current behavior (no tax drag)
  - `futures`: Section 1256 mark-to-market annual tax on gains (60/40 LTST blended rate ~26.8%)
  - `box_spread`: Tax-deferred capital gains via ETF + box financing, with annual dividend tax and crisis-driven spread widening
- Instrument-specific parameters (tax rates, financing spreads, dividend yields, crisis thresholds) are passed via `instrument_params` dict
- New `_compute_new_nw()` method in `LeveragedStockPortfolio` encapsulates instrument-specific return calculations

### CLI & Configuration
- Removed `--optimal-leverage` flag and `compute_optimal_leverage()` function
- Added `--leverage-instrument` flag (default: `generic`) to select instrument type
- Added `--instrument-sweep N` flag to run comparative analysis across all three instruments
- Added instrument-specific CLI arguments:
  - `--futures-tax-rate`, `--futures-spread`, `--futures-roll-cost`
  - `--box-spread`, `--box-div-yield`, `--box-div-tax-rate`, `--box-crisis-widening`
- Extended `SimulationConfig` with 9 new fields for instrument parameters and validation

### New Sweep & Plotting
- **`run_instrument_comparison()`** in `sweeps.py`: Runs leverage sweep for each instrument using common random numbers (CRN) for fair comparison
- **`plot_instrument_comparison()`** in `plotting.py`: Plots CE, ruin probability, and E[U] across leverage levels for all three instruments; prints summary table with optimal leverage and utility for each
- Removed Kelly-optimal leverage reference lines from existing leverage sweep plots

### Simulator Updates
- `run_simulation()` now configures instrument-specific margin spreads and parameters based on `config.leverage_instrument`
- Added `year_lev_margin_fee` and `year_stock_excess_return` closures to support instrument-specific cost calculations
- Removed Kelly-optimal leverage printout; added instrument-specific diagnostic output

### Documentation
- Updated `CLAUDE.md` with example `--instrument-sweep` command
- Updated file line counts and architecture notes
- Removed Kelly-optimal leverage references from `README.md` and `generate_advice.py`

## Implementation Details
- **Tax treatment**: Futures uses conservative annual mark-to-market (no loss carryforward); box spread defers cap gains but taxes dividends annually
- **Crisis modeling**: Box spread financing spread widens by 100bps when stock excess return falls below -10% (correlated drawdown scenario)
- **CRN fairness**: All three instruments use identical random seeds within `run_instrument_comparison()` for valid comparison
- **Backward compatibility**: Default `leverage_instrument='generic'` preserves existing behavior; existing CLI flags work unchanged

https://claude.ai/code/session_019wdaNfLqXrYquyrCenRvKF